### PR TITLE
Add a flag to avoid lens dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ install:
     fi
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all -fno-lens
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
@@ -96,6 +97,7 @@ script:
   - cat cabal.project
   # this builds all libraries and executables (without tests/benchmarks)
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all -fno-lens
 
   # Build with installed constraints for packages in global-db
   - if $INSTALLED; then echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi

--- a/insert-ordered-containers.cabal
+++ b/insert-ordered-containers.cabal
@@ -31,6 +31,11 @@ source-repository head
   type: git
   location: https://github.com/phadej/insert-ordered-containers
 
+flag no-lens
+  description:
+    Don't build instances for use with lens library
+  default: False
+
 library
   hs-source-dirs:
       src
@@ -40,12 +45,17 @@ library
     , aeson                 >=1.0.0.0  && <1.5
     , base-compat           >=0.6.0    && <0.11
     , hashable              >=1.2.3.3  && <1.4
-    , lens                  >=4.7      && <4.17
     , semigroupoids         >=4.3      && <5.3
     , semigroups            >=0.16.2.2 && <0.19
     , text                  >=1.2.0.6  && <1.3
     , transformers          >=0.3.0.0  && <0.6
     , unordered-containers  >=0.2.7.0  && <0.3
+  if !flag(no-lens)
+    build-depends: lens     >=4.7      && <4.17
+  else
+    build-depends: microlens              <0.5
+  if flag(no-lens)
+    cpp-options: -DNO_LENS_INSTANCES
   exposed-modules:
       Data.HashMap.Strict.InsOrd
   default-language: Haskell2010

--- a/src/Data/HashMap/Strict/InsOrd.hs
+++ b/src/Data/HashMap/Strict/InsOrd.hs
@@ -70,9 +70,11 @@ module Data.HashMap.Strict.InsOrd (
     fromList,
     toHashMap,
     fromHashMap,
+#ifndef NO_LENS_INSTANCES
     -- * Lenses
     hashMap,
     unorderedTraversal,
+#endif
     -- * Debugging
     valid,
     ) where
@@ -101,10 +103,14 @@ import           Text.ParserCombinators.ReadPrec (prec)
 import           Text.Read                       (Lexeme (..), Read (..), lexP,
                                                   parens, readListPrecDefault)
 
+#ifndef NO_LENS_INSTANCES
 import Control.Lens                     (At (..), FoldableWithIndex (..),
                                          FunctorWithIndex (..), Index, Iso, IxValue,
                                          Ixed (..), TraversableWithIndex (..),
                                          Traversal, iso, (<&>), _1, _2)
+#else
+import Lens.Micro (_1, _2)
+#endif
 import Control.Monad.Trans.State.Strict (State, runState, state)
 
 import           Data.HashMap.Strict (HashMap)
@@ -240,6 +246,7 @@ instance (Eq k, Hashable k, FromJSONKey k, FromJSON v) => FromJSON (InsOrdHashMa
 -- Lens
 -------------------------------------------------------------------------------
 
+#ifndef NO_LENS_INSTANCES
 type instance Index (InsOrdHashMap k v) = k
 type instance IxValue (InsOrdHashMap k v) = v
 
@@ -269,6 +276,7 @@ hashMap = iso toHashMap fromHashMap
 
 unorderedTraversal :: Traversal (InsOrdHashMap k a) (InsOrdHashMap k b) a b
 unorderedTraversal = hashMap . traverse
+#endif
 
 -------------------------------------------------------------------------------
 -- Construction


### PR DESCRIPTION
This adds a flag to optionally remove the lens dependency, allowing for smoother cross-compilation.