### PR TITLE
Add NFData instances to InsOrdHashMap and InsOrdHashSet

### DIFF
--- a/insert-ordered-containers.cabal
+++ b/insert-ordered-containers.cabal
@@ -46,6 +46,7 @@ library
     , text                  >=1.2.3.0 && <1.3
     , transformers          >=0.5.2.0 && <0.6
     , unordered-containers  >=0.2.8.0 && <0.3
+    , deepseq               >=1.1.0.0
 
   exposed-modules:
     Data.HashMap.Strict.InsOrd

--- a/src/Data/HashMap/Strict/InsOrd.hs
+++ b/src/Data/HashMap/Strict/InsOrd.hs
@@ -82,6 +82,7 @@ import Prelude.Compat hiding (filter, foldr, lookup, map, null)
 
 import           Control.Applicative             (Const (..))
 import           Control.Arrow                   (first, second)
+import           Control.DeepSeq                 (NFData, rnf)
 import           Data.Aeson
 import qualified Data.Aeson.Encoding             as E
 import           Data.Data                       (Data, Typeable)
@@ -122,6 +123,9 @@ import Data.HashMap.InsOrd.Internal
 data P a = P !Int !a
     deriving (Functor, Foldable, Traversable, Typeable, Data)
 
+instance NFData a => NFData (P a) where
+    rnf (P i a) = rnf i `seq` rnf a
+
 getPK :: P a -> Int
 getPK (P i _) = i
 {-# INLINABLE getPK #-}
@@ -147,13 +151,16 @@ instance Hashable a => Hashable (P a) where
 -- InsOrdHashMap
 -------------------------------------------------------------------------------
 
--- | 'HashMap' which tries it's best to remember insertion order of elements.
+-- | 'HashMap' which tries its best to remember insertion order of elements.
 
 data InsOrdHashMap k v = InsOrdHashMap
     { _getIndex        :: !Int
     , getInsOrdHashMap :: !(HashMap k (P v))
     }
     deriving (Functor, Typeable, Data)
+
+instance (NFData k, NFData v) => NFData (InsOrdHashMap k v) where
+    rnf (InsOrdHashMap index hm) = rnf index `seq` rnf hm
 
 instance (Eq k, Eq v) => Eq (InsOrdHashMap k v) where
     InsOrdHashMap _ a == InsOrdHashMap _ b = a == b

--- a/src/Data/HashSet/InsOrd.hs
+++ b/src/Data/HashSet/InsOrd.hs
@@ -47,6 +47,7 @@ import Prelude ()
 import Prelude.Compat hiding (filter, foldr, lookup, map, null)
 
 import Control.Arrow                   (first)
+import Control.DeepSeq                 (NFData, rnf)
 import Data.Aeson
 import Data.Data                       (Data, Typeable)
 import Data.Hashable                   (Hashable (..))
@@ -79,13 +80,16 @@ import Data.HashMap.InsOrd.Internal
 -- InsOrdHashSet
 -------------------------------------------------------------------------------
 
--- | 'HashSet' which tries it's best to remember insertion order of elements.
+-- | 'HashSet' which tries its best to remember insertion order of elements.
 
 data InsOrdHashSet k = InsOrdHashSet
     { _getIndex        :: !Int
     , getInsOrdHashSet :: !(HashMap k Int)
     }
     deriving (Typeable, Data)
+
+instance NFData k => NFData (InsOrdHashSet k) where
+    rnf (InsOrdHashSet index hs) = rnf index `seq` rnf hs
 
 instance Eq k => Eq (InsOrdHashSet k) where
     InsOrdHashSet _ a == InsOrdHashSet _ b = a == b


### PR DESCRIPTION
Just a small PR that adds `NFData` instances to `InsOrdHashSet` and `InsOrdHashMap`, relying on the corresponding instances from `HashMap`.