### PR TITLE
Allow `lens ^>=5.3`

### DIFF
--- a/insert-ordered-containers.cabal
+++ b/insert-ordered-containers.cabal
@@ -49,7 +49,7 @@ library
     , deepseq               >=1.4.2.0  && <1.6
     , hashable              >=1.2.6.1  && <1.5
     , indexed-traversable   >=0.1.1    && <0.2
-    , lens                  >=4.17     && <5.3
+    , lens                  >=4.17     && <5.4
     , optics-core           >=0.2      && <0.5
     , optics-extra          >=0.2      && <0.5
     , semigroupoids         >=5.3.2    && <6.1


### PR DESCRIPTION
We are successfully using `allow-newer: insert-ordered-containers:lens` internally, and this PR passes `cabal test --constraint 'lens ^>=5.3'`.

Can we please also have a Hackage metadata revision?