### PR TITLE
relax hashable bounds

### DIFF
--- a/insert-ordered-containers.cabal
+++ b/insert-ordered-containers.cabal
@@ -44,7 +44,7 @@ library
     , aeson                 >=2.2.3.0  && <2.3
     , base                  >=4.12.0.0 && <4.21
     , deepseq               >=1.4.4.0  && <1.6
-    , hashable              >=1.4.7.0  && <1.5
+    , hashable              >=1.4.7.0  && <1.6
     , indexed-traversable   >=0.1.4    && <0.2
     , lens                  >=5.2.3    && <5.4
     , optics-core           >=0.4.1.1  && <0.5


### PR DESCRIPTION
this has dropped out of stackage nightly because hashable 0.15.0 is in the nightly

https://github.com/Bodigrim/stackage/blob/f49e0bf4c789442d5b729aab05cec96b021d654f/build-constraints.yaml#L6945C49-L6945C80